### PR TITLE
Only build smooth ros tests if ROS2 detected

### DIFF
--- a/include/smooth/lie_group_base.hpp
+++ b/include/smooth/lie_group_base.hpp
@@ -68,9 +68,23 @@ public:
   //! Plain return type
   using PlainObject = CastT<Scalar>;
 
+  /*! @brief Access underlying storages */
+  template<bool = true>
+    requires(is_mutable)
+  auto & coeffs() const
+  {
+    return derived().coeffs();
+  }
   /*! @brief Const access underlying storages */
   const auto & coeffs() const { return cderived().coeffs(); }
 
+  /*! @brief Access raw pointer */
+  template<bool = true>
+    requires(is_mutable)
+  auto * data() const
+  {
+    return derived().data();
+  }
   /*! @brief Const access raw pointer */
   const auto * data() const { return cderived().data(); }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -152,7 +152,7 @@ else()
   message(WARNING "ceres not found, disabling ceres tests")
 endif()
 
-find_package(geometry_msgs QUIET)
+find_package(geometry_msgs 4.0.0 QUIET)
 if(geometry_msgs_FOUND)
   add_smooth_test(test_ros LINK_LIBRARIES geometry_msgs::geometry_msgs__rosidl_typesupport_cpp)
 else()


### PR DESCRIPTION
Also added non const  coeff() and data() to LieGroupBase
