### PR TITLE
Fix postfix operator implementation

### DIFF
--- a/include/smooth/detail/utils.hpp
+++ b/include/smooth/detail/utils.hpp
@@ -163,7 +163,7 @@ public:
       requires std::ranges::forward_range<R>
     {
       _Iterator tmp = *this;
-      ++this;
+      operator++();
       return tmp;
     }
 
@@ -178,7 +178,7 @@ public:
       requires std::ranges::bidirectional_range<R>
     {
       auto tmp = *this;
-      --this;
+      operator--();
       return tmp;
     }
 
@@ -318,7 +318,7 @@ public:
       requires(std::ranges::forward_range<View> && ...)
     {
       _Iterator tmp = *this;
-      ++this;
+      operator++();
       return tmp;
     }
 


### PR DESCRIPTION
`this`should be dereferenced before calling operators on it. Additionally, `++(*this)` would recurse in the same function, so `(*this)++` would be better, but opted for explicitly calling the function by name instead, i.e. `operator++()`


```
In file included from external/smooth/include/smooth/spline/fit.hpp:12:
In file included from external/smooth/include/smooth/spline/bspline.hpp:13:
In file included from external/smooth/include/smooth/spline/cumulative_spline.hpp:15:
In file included from external/smooth/include/smooth/spline/../polynomial/basis.hpp:12:
In file included from external/smooth/include/smooth/spline/../polynomial/static_matrix.hpp:13:
external/smooth/include/smooth/spline/../polynomial/../detail/utils.hpp:162:7: error: expression is not assignable
  162 |       ++this;
      |       ^ ~~~~
external/smooth/include/smooth/spline/../polynomial/../detail/utils.hpp:177:7: error: expression is not assignable
  177 |       --this;
      |       ^ ~~~~
external/smooth/include/smooth/spline/../polynomial/../detail/utils.hpp:317:7: error: expression is not assignable
  317 |       ++this;
      |       ^ ~~~~
3 errors generated.
```